### PR TITLE
feat: add dependencies to make work the live grep

### DIFF
--- a/bin/macos/core.sh
+++ b/bin/macos/core.sh
@@ -4,3 +4,6 @@
 
 brew install curl
 brew install wget
+brew install fd
+brew install ripgrep
+brew install bat 


### PR DESCRIPTION
It fixes the following error:
<img width="1375" alt="Screenshot 2022-01-21 at 3 52 45 PM" src="https://user-images.githubusercontent.com/1727543/150598602-123e9505-a47e-4ac9-bb2a-deba5d95a63b.png">
